### PR TITLE
refactor: harden so2x-flow thin harness contracts

### DIFF
--- a/.workflow/scripts/ccs_runner.py
+++ b/.workflow/scripts/ccs_runner.py
@@ -210,10 +210,17 @@ def run_role_subprocess(
     try:
         completed = subprocess.run(command, capture_output=True, text=True, timeout=timeout, check=True)
     except subprocess.TimeoutExpired:
-        raise RunnerError(f"runner={runner} role={role} timed out after {timeout}s: {preview}")
+        detail = f"runner={runner} role={role} timed out after {timeout}s: {preview}"
+        if fallback_reason:
+            detail = f"{detail}\nfallback_reason: {fallback_reason}"
+        raise RunnerError(detail)
     except subprocess.CalledProcessError as exc:
         hint = authentication_hint(runner, exc.stderr)
-        detail = f"runner={runner} role={role} exited {exc.returncode}: {preview}\nstderr: {exc.stderr}"
+        stdout = (getattr(exc, "output", None) or "").strip() or "(none)"
+        stderr = (exc.stderr or "").strip() or "(none)"
+        detail = f"runner={runner} role={role} exited {exc.returncode}: {preview}\nstdout: {stdout}\nstderr: {stderr}"
+        if fallback_reason:
+            detail = f"{detail}\nfallback_reason: {fallback_reason}"
         if hint:
             detail = f"{detail}\nhint: {hint}"
         raise RunnerError(detail) from exc

--- a/.workflow/scripts/execute.py
+++ b/.workflow/scripts/execute.py
@@ -2,9 +2,7 @@
 from __future__ import annotations
 
 import argparse
-import json
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
 
 import yaml
@@ -16,22 +14,10 @@ if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
 from ccs_runner import resolve_role_runner, resolve_runner, run_role, run_role_subprocess
-from task_artifacts import (
-    render_feature_task,
-    render_init_task,
-    render_plan_doc,
-    render_qa_task,
-    render_review_task,
-    save_task_payload,
-    write_initial_task,
-    write_plan_task,
-)
-from workflow_context import (
-    collect_docs,
-    load_docs_bundle,
-    select_approved_plan,
-    slugify,
-)
+from mode_handlers import prepare_mode_context
+from payloads import build_payload, print_summary
+from prompt_builder import build_prompt, load_text
+from task_artifacts import save_task_payload
 
 CONFIG_PATH = WORKFLOW_ROOT / "config" / "ccs-map.yaml"
 PLAN_TASKS = WORKFLOW_ROOT / "tasks" / "plan"
@@ -107,12 +93,6 @@ def load_config() -> dict:
     return yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8"))
 
 
-def load_text(path: Path) -> str:
-    if not path.exists():
-        raise SystemExit(f"file not found: {path}")
-    return path.read_text(encoding="utf-8")
-
-
 def ensure_bootstrap_files() -> list[str]:
     artifacts: list[str] = []
     for rel_dir in BOOTSTRAP_DIRS:
@@ -124,151 +104,30 @@ def ensure_bootstrap_files() -> list[str]:
     return artifacts
 
 
-def prompt_path_for_role(role: str) -> Path:
-    mapping = {
-        "planner": "planner.md",
-        "implementer": "implementer.md",
-        "qa_planner": "qa-planner.md",
-        "reviewer": "reviewer.md",
-    }
-    return PROMPTS_DIR / mapping[role]
-
-
-def load_prompt_template(role: str) -> str:
-    return load_text(prompt_path_for_role(role))
-
-
-def build_prompt(
-    role: str,
-    mode: str,
-    request: str,
-    docs_used: list[str],
-    docs_bundle: str,
-    task_path: str | None,
-    qa_id: str | None,
-    planner_output: str | None,
-    design_doc: str | None,
-    approved_plan_path: str | None = None,
-    approved_plan_match_reason: str | None = None,
-) -> str:
-    prompt_template = load_prompt_template(role)
-    lines = [
-        f"role: {role}",
-        f"mode: {mode}",
-        f"request: {request}",
-        f"docs_used: {', '.join(docs_used) if docs_used else '(none)'}",
-        f"design_doc: {design_doc or '(none)'}",
-        f"approved_plan_path: {approved_plan_path or '(none)'}",
-        f"approved_plan_match_reason: {approved_plan_match_reason or '(none)'}",
-        "",
-        "prompt_template:",
-        prompt_template.strip(),
-        "",
-        "docs_content:",
-        docs_bundle,
-    ]
-    if task_path:
-        task_file = PROJECT_ROOT / task_path
-        lines.extend(["", f"task_path: {task_path}", "task_content:", load_text(task_file).strip()])
-    if qa_id:
-        lines.append(f"qa_id: {qa_id}")
-    if planner_output:
-        lines.extend(["", "planner_output:", planner_output])
-    return "\n".join(lines)
-
-
-def print_summary(payload: dict) -> None:
-    print(f"mode: {payload['mode']}")
-    print(f"request: {payload['request']}")
-    print(f"dry_run: {payload['dry_run']}")
-    print(f"requested_runner: {payload['requested_runner']}")
-    print(f"selected_runner: {payload['selected_runner']}")
-    print(f"fallback_used: {payload['fallback_used']}")
-    print(f"fallback_reason: {payload['fallback_reason'] or '(none)'}")
-    print(f"design_doc: {payload['design_doc'] or '(none)'}")
-    print(f"approved_plan_path: {payload.get('approved_plan_path') or '(none)'}")
-    print(f"approved_plan_match_reason: {payload.get('approved_plan_match_reason') or '(none)'}")
-    print("docs_used:")
-    for doc in payload["docs_used"]:
-        print(f"  - {doc}")
-    print("roles:")
-    for item in payload["role_results"]:
-        print(f"  - {item['role']} ({item['status']})")
-    print("commands:")
-    for item in payload["role_results"]:
-        print(f"  - {item['role']}: {item['command_preview']}")
-    print("role_fallbacks:")
-    for item in payload["role_results"]:
-        print(f"  - {item['role']}: {item.get('fallback_reason') or '(none)'}")
-    print("role_outputs:")
-    for item in payload["role_results"]:
-        print(f"  - {item['role']} output:")
-        if item["output"]:
-            for line in item["output"].splitlines():
-                print(f"    {line}")
-        else:
-            print("    ")
-    print("artifacts:")
-    for artifact in payload["artifacts"]:
-        print(f"  - {artifact}")
-    print(f"output_json: {payload['output_json']}")
-
-
 def main() -> int:
     args = parse_args()
     mode = canonical_mode(args.mode)
     bootstrap_artifacts = ensure_bootstrap_files() if mode == "init" else []
-    artifacts = list(bootstrap_artifacts) if mode == "init" else []
     config = load_config()
-    docs_used, design_doc = collect_docs(PROJECT_ROOT, WORKFLOW_ROOT, mode, args.docs, args.task, args.with_design)
-    docs_bundle = load_docs_bundle(PROJECT_ROOT, docs_used, load_text)
-    configured_roles = config["modes"][mode]["roles"]
-    skip_roles = {"planner", "qa_planner"} if args.skip_plan else set()
-    roles = [] if mode == "init" else [role for role in configured_roles if role not in skip_roles]
-    planner_output = None
-    task_path = None
-    approved_plan_path = None
-    approved_plan_match_reason = None
-
-    if mode == "feature":
-        approved_plan_path, approved_plan_match_reason = select_approved_plan(PROJECT_ROOT, PLAN_TASKS, args.request, require_explicit_approval=args.skip_plan)
-        if approved_plan_path and approved_plan_path not in docs_used:
-            docs_used.append(approved_plan_path)
-            docs_bundle = load_docs_bundle(PROJECT_ROOT, docs_used, load_text)
-        if args.skip_plan and approved_plan_path is None:
-            raise SystemExit("skip-plan requires an explicitly approved plan artifact; run /flow-plan, mark it approved, or omit --skip-plan")
-        task_path = f".workflow/tasks/feature/{slugify(args.request)}.json"
-        path = PROJECT_ROOT / task_path
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(render_feature_task(args.request, approved_plan_path), ensure_ascii=False, indent=2), encoding="utf-8")
-        artifacts.append(task_path)
-    elif mode == "init":
-        task_path = f".workflow/tasks/init/{slugify(args.request)}.json"
-        path = PROJECT_ROOT / task_path
-        path.parent.mkdir(parents=True, exist_ok=True)
-        write_initial_task(path, render_init_task(args.request), preserve_existing=True)
-        artifacts = [task_path]
-    elif mode == "qa":
-        task_path = f".workflow/tasks/qa/{slugify(args.request)}.json"
-        path = PROJECT_ROOT / task_path
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(render_qa_task(args.request, args.qa_id), ensure_ascii=False, indent=2), encoding="utf-8")
-        artifacts.append(task_path)
-    elif mode == "plan":
-        task_path = f".workflow/tasks/plan/{slugify(args.request)}.json"
-        path = PROJECT_ROOT / task_path
-        path.parent.mkdir(parents=True, exist_ok=True)
-        write_plan_task(path, render_plan_doc(args.request, docs_used))
-        artifacts.append(task_path)
-    elif mode == "review":
-        task_path = f".workflow/tasks/review/{slugify(args.request)}.json"
-        path = PROJECT_ROOT / task_path
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(
-            json.dumps(render_review_task(args.request, docs_used, args.task), ensure_ascii=False, indent=2),
-            encoding="utf-8",
-        )
-        artifacts.append(task_path)
+    context = prepare_mode_context(
+        project_root=PROJECT_ROOT,
+        workflow_root=WORKFLOW_ROOT,
+        plan_tasks=PLAN_TASKS,
+        config=config,
+        mode=mode,
+        request=args.request,
+        docs=args.docs,
+        task=args.task,
+        qa_id=args.qa_id,
+        skip_plan=args.skip_plan,
+        with_design=args.with_design,
+        load_text=load_text,
+    )
+    artifacts = list(bootstrap_artifacts) if mode == "init" else []
+    if mode == "init":
+        artifacts = list(context.artifacts)
+    else:
+        artifacts.extend(context.artifacts)
 
     runtime_config = config.get("runtime", {})
     allow_live_run_raw = runtime_config.get("allow_live_run", False)
@@ -279,12 +138,10 @@ def main() -> int:
         raise SystemExit("live execution blocked: set runtime.allow_live_run=true or use --dry-run")
     resolution = resolve_runner(runtime_config.get("runner", "auto"))
     role_results = []
-    for role in roles:
+    planner_output = context.planner_output
+    for role in context.roles:
         requested_role_config = config["roles"][role][resolution.selected_runner]
-        shared_role_config = {
-            **config["roles"][role],
-            **requested_role_config,
-        }
+        shared_role_config = {**config["roles"][role], **requested_role_config}
         role_resolution = resolve_role_runner(
             requested_runner=resolution.selected_runner,
             role=role,
@@ -292,11 +149,22 @@ def main() -> int:
             runtime_config=runtime_config,
         )
         active_role_config = config["roles"][role][role_resolution.selected_runner]
-        shared_role_config = {
-            **config["roles"][role],
-            **active_role_config,
-        }
-        prompt = build_prompt(role, mode, args.request, docs_used, docs_bundle, task_path, args.qa_id, planner_output, design_doc, approved_plan_path, approved_plan_match_reason)
+        shared_role_config = {**config["roles"][role], **active_role_config}
+        prompt = build_prompt(
+            prompts_dir=PROMPTS_DIR,
+            project_root=PROJECT_ROOT,
+            role=role,
+            mode=mode,
+            request=args.request,
+            docs_used=context.docs_used,
+            docs_bundle=context.docs_bundle,
+            task_path=context.task_path,
+            qa_id=args.qa_id,
+            planner_output=planner_output,
+            design_doc=context.design_doc,
+            approved_plan_path=context.approved_plan_path,
+            approved_plan_match_reason=context.approved_plan_match_reason,
+        )
         if args.dry_run:
             result = run_role(
                 runner=role_resolution.selected_runner,
@@ -332,23 +200,19 @@ def main() -> int:
         if role in {"planner", "qa_planner"}:
             planner_output = result.output
 
-    payload = {
-        "mode": mode,
-        "request": args.request,
-        "dry_run": args.dry_run,
-        "requested_runner": resolution.requested_runner,
-        "selected_runner": resolution.selected_runner,
-        "fallback_used": resolution.fallback_used,
-        "fallback_reason": resolution.fallback_reason,
-        "design_doc": design_doc,
-        "approved_plan_path": approved_plan_path,
-        "approved_plan_match_reason": approved_plan_match_reason,
-        "docs_used": docs_used,
-        "roles": roles,
-        "role_results": role_results,
-        "artifacts": artifacts,
-        "output_json": artifacts[0] if artifacts and artifacts[0].endswith(".json") else "",
-    }
+    payload = build_payload(
+        mode=mode,
+        request=args.request,
+        dry_run=args.dry_run,
+        resolution=resolution,
+        design_doc=context.design_doc,
+        approved_plan_path=context.approved_plan_path,
+        approved_plan_match_reason=context.approved_plan_match_reason,
+        docs_used=context.docs_used,
+        roles=context.roles,
+        role_results=role_results,
+        artifacts=artifacts,
+    )
     json_path = save_task_payload(PROJECT_ROOT, payload)
     if json_path is not None:
         payload["output_json"] = str(json_path.relative_to(PROJECT_ROOT))

--- a/.workflow/scripts/install.py
+++ b/.workflow/scripts/install.py
@@ -105,6 +105,8 @@ def main() -> int:
 
     print("step 4/4: install complete")
     print("next_step: flow-init으로 이 프로젝트를 초기화해줘.")
+    print("next_step_cli: /flow-init")
+    print("first_run_path: /flow-init -> /flow-plan -> /flow-feature")
     print(f"target: {target_root}")
     print(f"copied_count: {len(copied)}")
     for item in copied:

--- a/.workflow/scripts/mode_handlers.py
+++ b/.workflow/scripts/mode_handlers.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from task_artifacts import (
+    render_feature_task,
+    render_init_task,
+    render_plan_doc,
+    render_qa_task,
+    render_review_task,
+    write_initial_task,
+    write_plan_task,
+)
+from workflow_context import collect_docs, load_docs_bundle, select_approved_plan, slugify
+
+
+@dataclass
+class ModeContext:
+    docs_used: list[str]
+    docs_bundle: str
+    design_doc: str | None
+    roles: list[str]
+    planner_output: str | None
+    task_path: str | None
+    artifacts: list[str]
+    approved_plan_path: str | None
+    approved_plan_match_reason: str | None
+
+
+def prepare_mode_context(
+    *,
+    project_root: Path,
+    workflow_root: Path,
+    plan_tasks: Path,
+    config: dict,
+    mode: str,
+    request: str,
+    docs: list[str] | None,
+    task: str | None,
+    qa_id: str | None,
+    skip_plan: bool,
+    with_design: bool,
+    load_text,
+) -> ModeContext:
+    docs_used, design_doc = collect_docs(project_root, workflow_root, mode, docs, task, with_design)
+    docs_bundle = load_docs_bundle(project_root, docs_used, load_text)
+    configured_roles = config["modes"][mode]["roles"]
+    skip_roles = {"planner", "qa_planner"} if skip_plan else set()
+    roles = [] if mode == "init" else [role for role in configured_roles if role not in skip_roles]
+    planner_output = None
+    task_path = None
+    approved_plan_path = None
+    approved_plan_match_reason = None
+    artifacts: list[str] = []
+
+    if mode == "feature":
+        approved_plan_path, approved_plan_match_reason = select_approved_plan(
+            project_root,
+            plan_tasks,
+            request,
+            require_explicit_approval=skip_plan,
+        )
+        if approved_plan_path and approved_plan_path not in docs_used:
+            docs_used.append(approved_plan_path)
+            docs_bundle = load_docs_bundle(project_root, docs_used, load_text)
+        if skip_plan and approved_plan_path is None:
+            raise SystemExit("skip-plan requires an explicitly approved plan artifact; run /flow-plan, mark it approved, or omit --skip-plan")
+        task_path = f".workflow/tasks/feature/{slugify(request)}.json"
+        path = project_root / task_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(render_feature_task(request, approved_plan_path), ensure_ascii=False, indent=2), encoding='utf-8')
+        artifacts.append(task_path)
+    elif mode == "init":
+        task_path = f".workflow/tasks/init/{slugify(request)}.json"
+        path = project_root / task_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        write_initial_task(path, render_init_task(request), preserve_existing=True)
+        artifacts = [task_path]
+        roles = []
+    elif mode == "qa":
+        task_path = f".workflow/tasks/qa/{slugify(request)}.json"
+        path = project_root / task_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(render_qa_task(request, qa_id), ensure_ascii=False, indent=2), encoding='utf-8')
+        artifacts.append(task_path)
+    elif mode == "plan":
+        task_path = f".workflow/tasks/plan/{slugify(request)}.json"
+        path = project_root / task_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        write_plan_task(path, render_plan_doc(request, docs_used))
+        artifacts.append(task_path)
+    elif mode == "review":
+        task_path = f".workflow/tasks/review/{slugify(request)}.json"
+        path = project_root / task_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(render_review_task(request, docs_used, task), ensure_ascii=False, indent=2), encoding='utf-8')
+        artifacts.append(task_path)
+
+    return ModeContext(
+        docs_used=docs_used,
+        docs_bundle=docs_bundle,
+        design_doc=design_doc,
+        roles=roles,
+        planner_output=planner_output,
+        task_path=task_path,
+        artifacts=artifacts,
+        approved_plan_path=approved_plan_path,
+        approved_plan_match_reason=approved_plan_match_reason,
+    )

--- a/.workflow/scripts/payloads.py
+++ b/.workflow/scripts/payloads.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+
+def build_payload(
+    *,
+    mode: str,
+    request: str,
+    dry_run: bool,
+    resolution,
+    design_doc: str | None,
+    approved_plan_path: str | None,
+    approved_plan_match_reason: str | None,
+    docs_used: list[str],
+    roles: list[str],
+    role_results: list[dict],
+    artifacts: list[str],
+) -> dict:
+    return {
+        "mode": mode,
+        "request": request,
+        "dry_run": dry_run,
+        "requested_runner": resolution.requested_runner,
+        "selected_runner": resolution.selected_runner,
+        "fallback_used": resolution.fallback_used,
+        "fallback_reason": resolution.fallback_reason,
+        "design_doc": design_doc,
+        "approved_plan_path": approved_plan_path,
+        "approved_plan_match_reason": approved_plan_match_reason,
+        "docs_used": docs_used,
+        "roles": roles,
+        "role_results": role_results,
+        "artifacts": artifacts,
+        "output_json": artifacts[0] if artifacts and artifacts[0].endswith('.json') else '',
+    }
+
+
+
+def print_summary(payload: dict) -> None:
+    print(f"mode: {payload['mode']}")
+    print(f"request: {payload['request']}")
+    print(f"dry_run: {payload['dry_run']}")
+    print(f"requested_runner: {payload['requested_runner']}")
+    print(f"selected_runner: {payload['selected_runner']}")
+    print(f"fallback_used: {payload['fallback_used']}")
+    print(f"fallback_reason: {payload['fallback_reason'] or '(none)'}")
+    print(f"design_doc: {payload['design_doc'] or '(none)'}")
+    print(f"approved_plan_path: {payload.get('approved_plan_path') or '(none)'}")
+    print(f"approved_plan_match_reason: {payload.get('approved_plan_match_reason') or '(none)'}")
+    print("docs_used:")
+    for doc in payload["docs_used"]:
+        print(f"  - {doc}")
+    print("roles:")
+    for item in payload["role_results"]:
+        print(f"  - {item['role']} ({item['status']})")
+    print("commands:")
+    for item in payload["role_results"]:
+        print(f"  - {item['role']}: {item['command_preview']}")
+    print("role_fallbacks:")
+    for item in payload["role_results"]:
+        print(f"  - {item['role']}: {item.get('fallback_reason') or '(none)'}")
+    print("role_outputs:")
+    for item in payload["role_results"]:
+        print(f"  - {item['role']} output:")
+        if item["output"]:
+            for line in item["output"].splitlines():
+                print(f"    {line}")
+        else:
+            print("    ")
+    print("artifacts:")
+    for artifact in payload["artifacts"]:
+        print(f"  - {artifact}")
+    print(f"output_json: {payload['output_json']}")

--- a/.workflow/scripts/prompt_builder.py
+++ b/.workflow/scripts/prompt_builder.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def load_text(path: Path) -> str:
+    if not path.exists():
+        raise SystemExit(f"file not found: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def prompt_path_for_role(prompts_dir: Path, role: str) -> Path:
+    mapping = {
+        "planner": "planner.md",
+        "implementer": "implementer.md",
+        "qa_planner": "qa-planner.md",
+        "reviewer": "reviewer.md",
+    }
+    return prompts_dir / mapping[role]
+
+
+def load_prompt_template(prompts_dir: Path, role: str) -> str:
+    return load_text(prompt_path_for_role(prompts_dir, role))
+
+
+def build_prompt(
+    *,
+    prompts_dir: Path,
+    project_root: Path,
+    role: str,
+    mode: str,
+    request: str,
+    docs_used: list[str],
+    docs_bundle: str,
+    task_path: str | None,
+    qa_id: str | None,
+    planner_output: str | None,
+    design_doc: str | None,
+    approved_plan_path: str | None = None,
+    approved_plan_match_reason: str | None = None,
+) -> str:
+    prompt_template = load_prompt_template(prompts_dir, role)
+    lines = [
+        f"role: {role}",
+        f"mode: {mode}",
+        f"request: {request}",
+        f"docs_used: {', '.join(docs_used) if docs_used else '(none)'}",
+        f"design_doc: {design_doc or '(none)'}",
+        f"approved_plan_path: {approved_plan_path or '(none)'}",
+        f"approved_plan_match_reason: {approved_plan_match_reason or '(none)'}",
+        "",
+        "prompt_template:",
+        prompt_template.strip(),
+        "",
+        "docs_content:",
+        docs_bundle,
+    ]
+    if task_path:
+        task_file = project_root / task_path
+        lines.extend(["", f"task_path: {task_path}", "task_content:", load_text(task_file).strip()])
+    if qa_id:
+        lines.append(f"qa_id: {qa_id}")
+    if planner_output:
+        lines.extend(["", "planner_output:", planner_output])
+    return "\n".join(lines)

--- a/.workflow/scripts/task_artifacts.py
+++ b/.workflow/scripts/task_artifacts.py
@@ -3,6 +3,82 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+ARTIFACT_SCHEMAS = {
+    "feature": {
+        "title": str,
+        "summary": str,
+        "context": list,
+        "related_docs": list,
+        "latest_approved_flow_plan_output": str,
+        "approved_direction": dict,
+        "approval_gate": list,
+        "implementation_slice": list,
+        "relevant_files": list,
+        "out_of_scope": list,
+        "proposed_steps": list,
+        "acceptance": list,
+        "verification": list,
+        "follow_up_slice": list,
+        "next_step_prompt": str,
+    },
+    "qa": {
+        "title": str,
+        "issue_summary": str,
+        "qa_id": str,
+        "references": list,
+        "reproduction": list,
+        "expected": list,
+        "actual": list,
+        "suspected_scope": list,
+        "minimal_fix": list,
+        "regression_checklist": list,
+    },
+    "review": {
+        "title": str,
+        "related_docs": list,
+        "review_focus": list,
+        "findings": list,
+        "next_step_prompt": str,
+    },
+    "init": {
+        "title": str,
+        "status": str,
+        "questions": list,
+        "next_step_prompt": str,
+    },
+    "plan": {
+        "request": str,
+        "status": str,
+        "approved": bool,
+        "related_docs": list,
+        "context_snapshot": str,
+        "open_questions": list,
+        "options": dict,
+        "recommendation": str,
+        "draft_plan": list,
+        "approval_gate": list,
+        "next_step_prompt": str,
+    },
+}
+
+
+def validate_artifact(kind: str, payload: dict) -> dict:
+    schema = ARTIFACT_SCHEMAS.get(kind)
+    if schema is None:
+        raise ValueError(f"unsupported artifact kind: {kind}")
+    if not isinstance(payload, dict):
+        raise ValueError(f"{kind} artifact must be a dict")
+    for field, expected_type in schema.items():
+        if field not in payload:
+            raise ValueError(f"{kind} missing required field: {field}")
+        if not isinstance(payload[field], expected_type):
+            raise ValueError(f"{kind} field '{field}' must be of type {expected_type.__name__}")
+    return payload
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
 
 def render_feature_task(request: str, approved_plan_path: str | None = None) -> dict:
     plan_ref = approved_plan_path or "(none matched request)"
@@ -12,7 +88,7 @@ def render_feature_task(request: str, approved_plan_path: str | None = None) -> 
     else:
         next_step_prompt = "이 요청은 아직 승인된 방향이 없으니, /flow-plan으로 먼저 범위를 확정할까요? (y/n)"
         approval_hint = "승인된 plan이 없으면 여기서 멈추고 /flow-plan으로 먼저 범위를 확정할지 묻는다."
-    return {
+    return validate_artifact("feature", {
         "title": request,
         "summary": f"Requested feature: {request}",
         "context": ["Capture user-facing context and constraints here."],
@@ -40,12 +116,12 @@ def render_feature_task(request: str, approved_plan_path: str | None = None) -> 
         "verification": ["List the checks required before considering this slice done."],
         "follow_up_slice": ["Describe the next smallest slice after this one."],
         "next_step_prompt": next_step_prompt,
-    }
+    })
 
 
 def render_qa_task(request: str, qa_id: str | None) -> dict:
     qa_label = qa_id or "QA-TBD"
-    return {
+    return validate_artifact("qa", {
         "title": request,
         "issue_summary": "Summarize the bug and affected user flow.",
         "qa_id": qa_label,
@@ -63,11 +139,11 @@ def render_qa_task(request: str, qa_id: str | None) -> dict:
             "Adjacent flow still works",
             "No broader scope added without approval",
         ],
-    }
+    })
 
 
 def render_review_task(request: str, docs_used: list[str], task: str | None = None) -> dict:
-    return {
+    payload = {
         "title": request,
         "related_docs": docs_used,
         "related_task": task,
@@ -80,10 +156,12 @@ def render_review_task(request: str, docs_used: list[str], task: str | None = No
         "findings": [],
         "next_step_prompt": "이 리뷰 결과를 기준으로 후속 수정이 필요할까요? (y/n)",
     }
+    validate_artifact("review", payload)
+    return payload
 
 
 def render_init_task(request: str) -> dict:
-    return {
+    return validate_artifact("init", {
         "title": request,
         "status": "needs_user_input",
         "questions": [
@@ -97,11 +175,11 @@ def render_init_task(request: str) -> dict:
             {"id": "design", "question": "디자인/UX 기준이 있나요? 없으면 원하는 분위기를 알려주세요.", "target_doc": "DESIGN.md"},
         ],
         "next_step_prompt": "위 질문들에 답해주면 flow-init이 문서를 하나씩 채워갈게요.",
-    }
+    })
 
 
 def render_plan_doc(request: str, docs_used: list[str]) -> dict:
-    return {
+    return validate_artifact("plan", {
         "request": request,
         "status": "draft",
         "approved": False,
@@ -125,7 +203,7 @@ def render_plan_doc(request: str, docs_used: list[str]) -> dict:
             "승인 전에는 /flow-feature로 자동 전환하거나 다음 실행을 기정사실화하지 않는다.",
         ],
         "next_step_prompt": "이 설계 방향으로 확정할까요? (y/n)",
-    }
+    })
 
 
 def save_task_payload(project_root: Path, payload: dict) -> Path | None:
@@ -145,6 +223,7 @@ def save_task_payload(project_root: Path, payload: dict) -> Path | None:
 
 
 def write_initial_task(path: Path, content: dict, preserve_existing: bool = False) -> None:
+    validate_artifact("init", content)
     if preserve_existing and path.exists():
         existing = json.loads(path.read_text(encoding="utf-8"))
         merged = {**existing}
@@ -154,16 +233,19 @@ def write_initial_task(path: Path, content: dict, preserve_existing: bool = Fals
         merged["status"] = existing.get("status", "needs_user_input") if has_answers else "needs_user_input"
         merged["questions"] = content["questions"]
         merged["next_step_prompt"] = content["next_step_prompt"]
-        path.write_text(json.dumps(merged, ensure_ascii=False, indent=2), encoding="utf-8")
+        validate_artifact("init", merged)
+        write_json(path, merged)
         return
-    path.write_text(json.dumps(content, ensure_ascii=False, indent=2), encoding="utf-8")
+    write_json(path, content)
 
 
 def write_plan_task(path: Path, content: dict) -> None:
+    validate_artifact("plan", content)
     if path.exists():
         existing = json.loads(path.read_text(encoding="utf-8"))
         if existing.get("approved") is True:
             content["approved"] = True
         if existing.get("status") == "approved":
             content["status"] = "approved"
-    path.write_text(json.dumps(content, ensure_ascii=False, indent=2), encoding="utf-8")
+    validate_artifact("plan", content)
+    write_json(path, content)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@
 - Start ambiguous or new requirements with `flow-plan` first.
 - `flow-plan` absorbs brainstorming + writing-plans and leaves an approved canonical plan artifact.
 - For feature work, only execute `flow-feature` after an approved plan exists, then create the feature task document first.
+- 승인된 plan이 없으면 여기서 멈추고 `flow-plan`으로 먼저 범위를 확정할지 묻는다.
 - For QA work, create `.workflow/tasks/qa/<slug>.json` first.
 - `Proposed Steps` must exist before implementation.
 - New behavior or bugfix work should prefer TDD: failing reproduction/test first, then minimal code.
@@ -44,8 +45,10 @@
 - Slice completion should pass a review gate (spec compliance / quality / regression risk) before being treated as done.
 - If work splits cleanly, prefer subagent-style task isolation per slice rather than one giant mixed execution context.
 - Use `.workflow/config/ccs-map.yaml` to select `auto`, `ccs`, or `claude` runner.
+- Canonical plan artifacts live at `.workflow/tasks/plan/<slug>.json`.
 - In v0, `.workflow/scripts/execute.py` is validated primarily in `--dry-run` mode.
 - `runtime.allow_live_run` must be a real YAML boolean (`true` or `false`), not a string.
 - `ccs` shortcut roles run as `ccs <profile> "prompt"`; do not assume `-p` or `--model` for shortcut execution.
 - If a configured `ccs_profile` is missing, execute-level preflight falls back that role to `claude -p` when Claude is available; the reason is printed in `fallback_reason`.
+- role별 `ccs_profile`이 없으면 그 role만 `claude -p`로 fallback하고 이유를 role 결과에 남긴다.
 - Use `.claude/settings.json` hooks as deterministic guardrails; do not rely on CLAUDE.md text alone for enforcement.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,15 @@ rmdir .tmp 2>/dev/null || true
 - init은 planner를 돌리지 않고 `.workflow/tasks/init/<slug>.json` 질문지만 유지/갱신한다.
 - 즉, 설치와 운영 초기화는 일부러 분리돼 있다. 파일 배포는 install, 워크플로우 실행은 init 질문지 작성이다.
 
+## 처음 3단계
+
+1. `/flow-init`으로 PRD/ARCHITECTURE/QA/DESIGN 질문지를 만든다.
+2. 요구사항이 아직 크거나 애매하면 `/flow-plan`부터 돌린다.
+3. 승인된 plan이 생긴 뒤에만 `/flow-feature`로 들어간다.
+
+마지막 한 줄 안내는 항상 이걸 기준으로 보면 된다.
+- 다음 단계: /flow-init으로 프로젝트를 초기화하세요.
+
 ## 언제 무엇부터 시작하나
 
 ### `flow-plan`으로 시작

--- a/tests/test_ccs_runner.py
+++ b/tests/test_ccs_runner.py
@@ -133,7 +133,39 @@ def test_run_role_subprocess_command_failure_raises_runner_error_with_stderr(mon
         message = str(exc)
         assert "runner=ccs role=planner exited 17" in message
         assert "stderr: boom" in message
+        assert "stdout: (none)" in message
         assert "ccs codex hello" in message
+    else:
+        raise AssertionError("Expected RunnerError for subprocess failure path")
+
+
+def test_run_role_subprocess_command_failure_includes_stdout_and_fallback_reason(monkeypatch):
+    def fake_run(*args, **kwargs):
+        raise runner.subprocess.CalledProcessError(
+            returncode=9,
+            cmd=args[0],
+            output="partial-output",
+            stderr="bad things happened",
+        )
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    try:
+        runner.run_role_subprocess(
+            runner="claude",
+            role="implementer",
+            prompt="hello",
+            role_config={"command": "claude", "claude_role": "implementer"},
+            runtime_config={"claude_headless_flag": "-p"},
+            timeout=11,
+            fallback_reason="role=implementer profile 'glm' is not available via ccs",
+        )
+    except runner.RunnerError as exc:
+        message = str(exc)
+        assert "runner=claude role=implementer exited 9" in message
+        assert "stdout: partial-output" in message
+        assert "stderr: bad things happened" in message
+        assert "fallback_reason: role=implementer profile 'glm' is not available via ccs" in message
     else:
         raise AssertionError("Expected RunnerError for subprocess failure path")
 

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -451,9 +451,16 @@ def test_requested_ccs_falls_back_to_claude_when_ccs_missing(tmp_path: Path):
 
 def test_execute_uses_runner_resolution_layer_and_live_runner_path(tmp_path: Path):
     execute = (ROOT / ".workflow" / "scripts" / "execute.py").read_text(encoding="utf-8")
+    prompt_builder = (ROOT / ".workflow" / "scripts" / "prompt_builder.py").read_text(encoding="utf-8")
+    mode_handlers = (ROOT / ".workflow" / "scripts" / "mode_handlers.py").read_text(encoding="utf-8")
+    payloads = (ROOT / ".workflow" / "scripts" / "payloads.py").read_text(encoding="utf-8")
     assert "from ccs_runner import resolve_role_runner, resolve_runner, run_role, run_role_subprocess" in execute
-    assert "from task_artifacts import (" in execute
-    assert "from workflow_context import (" in execute
+    assert "from mode_handlers import prepare_mode_context" in execute
+    assert "from payloads import build_payload, print_summary" in execute
+    assert "from prompt_builder import build_prompt" in execute
+    assert "def build_prompt(" in prompt_builder
+    assert "def prepare_mode_context(" in mode_handlers
+    assert "def build_payload(" in payloads
 
     workspace = make_workspace(tmp_path)
     fake_runner = workspace / "fake-claude.sh"

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -1,3 +1,4 @@
+import importlib.util
 import json
 import subprocess
 import sys
@@ -618,3 +619,41 @@ def test_live_feature_role_can_fallback_to_claude_when_ccs_profile_missing(tmp_p
     assert "role=implementer profile 'missing-profile' is not available via ccs" in payload["role_results"][1]["fallback_reason"]
     assert "role=implementer profile 'missing-profile' is not available via ccs" in result.stdout
     assert payload["role_results"][1]["output"] == "claude-live-ok\n"
+
+
+def test_artifact_validation_rejects_missing_required_plan_field(tmp_path: Path):
+    workspace = make_workspace(tmp_path)
+    task_artifacts = workspace / ".workflow" / "scripts" / "task_artifacts.py"
+    spec = importlib.util.spec_from_file_location("so2x_flow_task_artifacts", task_artifacts)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    invalid_plan = module.render_plan_doc("결제 기능 작업 분해", [".workflow/docs/PRD.md"])
+    invalid_plan.pop("next_step_prompt")
+
+    try:
+        module.validate_artifact("plan", invalid_plan)
+    except ValueError as exc:
+        assert "plan missing required field: next_step_prompt" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for invalid plan artifact")
+
+
+def test_artifact_validation_rejects_wrong_feature_field_type(tmp_path: Path):
+    workspace = make_workspace(tmp_path)
+    task_artifacts = workspace / ".workflow" / "scripts" / "task_artifacts.py"
+    spec = importlib.util.spec_from_file_location("so2x_flow_task_artifacts", task_artifacts)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    invalid_feature = module.render_feature_task("로그인 기능 구현")
+    invalid_feature["verification"] = "not-a-list"
+
+    try:
+        module.validate_artifact("feature", invalid_feature)
+    except ValueError as exc:
+        assert "feature field 'verification' must be of type list" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for invalid feature artifact")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -175,3 +175,28 @@ def test_readme_install_prompt_forces_single_turn_completion_without_recap_only(
     assert "1~4단계를 한 턴에서 끝까지 실제로 실행한 뒤 마지막에만 결과를 짧게 정리해" in readme
     assert 'recap이나 "다음으로 ~ 하면 됩니다" 같은 안내만 남기지 말고' in readme
     assert '문구는 정확히 `다음 단계: /flow-init으로 프로젝트를 초기화하세요.` 로 써' in readme
+
+
+def test_core_workflow_contracts_are_consistent_across_readme_claude_and_flow_docs():
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    claude = (ROOT / "CLAUDE.md").read_text(encoding="utf-8")
+    feature_command = (ROOT / ".claude" / "commands" / "flow-feature.md").read_text(encoding="utf-8")
+    plan_command = (ROOT / ".claude" / "commands" / "flow-plan.md").read_text(encoding="utf-8")
+    feature_skill = (ROOT / ".claude" / "skills" / "flow-feature.md").read_text(encoding="utf-8")
+    plan_skill = (ROOT / ".claude" / "skills" / "flow-plan.md").read_text(encoding="utf-8")
+
+    shared_contracts = [
+        "role별 `ccs_profile`이 없으면 그 role만 `claude -p`로 fallback",
+        "승인된 plan이 없으면",
+        ".workflow/tasks/plan/<slug>.json",
+    ]
+    for contract in shared_contracts:
+        assert contract in readme
+        assert contract in claude
+
+    assert "승인된 plan이 없으면 여기서 멈추고 `flow-plan`으로 먼저 범위를 확정할지 묻는다" in feature_command
+    assert "승인된 plan이 없으면 여기서 멈추고 `flow-plan` 선행 여부를 먼저 묻는다" in feature_skill
+    assert "승인 전에는 `/flow-feature`로 자동 전환" in plan_skill
+    assert "승인 전에는 `/flow-feature`로 자동 전환" in plan_command
+    assert "설치와 운영 초기화는 일부러 분리돼 있다" in readme
+    assert "Use `.claude/settings.json` hooks as deterministic guardrails" in claude

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -177,6 +177,19 @@ def test_readme_install_prompt_forces_single_turn_completion_without_recap_only(
     assert '문구는 정확히 `다음 단계: /flow-init으로 프로젝트를 초기화하세요.` 로 써' in readme
 
 
+def test_install_output_and_readme_show_one_obvious_next_action():
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    install_script = (ROOT / ".workflow" / "scripts" / "install.py").read_text(encoding="utf-8")
+    assert "다음 단계: /flow-init으로 프로젝트를 초기화하세요." in readme
+    assert "처음 3단계" in readme
+    assert "1. `/flow-init`으로 PRD/ARCHITECTURE/QA/DESIGN 질문지를 만든다." in readme
+    assert "2. 요구사항이 아직 크거나 애매하면 `/flow-plan`부터 돌린다." in readme
+    assert "3. 승인된 plan이 생긴 뒤에만 `/flow-feature`로 들어간다." in readme
+    assert "next_step: flow-init으로 이 프로젝트를 초기화해줘." in install_script
+    assert "next_step_cli: /flow-init" in install_script
+    assert "first_run_path: /flow-init -> /flow-plan -> /flow-feature" in install_script
+
+
 def test_core_workflow_contracts_are_consistent_across_readme_claude_and_flow_docs():
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     claude = (ROOT / "CLAUDE.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- split `execute.py` into thinner orchestration helpers
- improve live runner failure diagnostics with stdout/fallback context
- add workflow task artifact validation
- lock shared workflow doc contracts across README/CLAUDE/flow docs
- clarify install output and first-run path

## Issues
- Closes #1
- Closes #2
- Closes #3
- Closes #4
- Closes #5

## Test Plan
- `pytest tests/test_execute.py tests/test_ccs_runner.py tests/test_install.py -q`

## Notes
- keeps the thin-harness direction
- preserves current dry-run behavior while tightening contracts and onboarding guidance
