### PR TITLE
Add release handoff docs for workflow refactor

### DIFF
--- a/RELEASE_BODY.md
+++ b/RELEASE_BODY.md
@@ -1,8 +1,9 @@
 ## Summary
 This PR adds release handoff documents for the workflow-contracts validation refactor that is already merged on `main`.
 
-## Commit in this branch
+## Commits in this branch
 - 8636e87 Add release handoff docs for workflow refactor
+- 53da8c6 docs: align release handoff with current PR
 
 ## Added files
 - `RELEASE_NOTES.md`

--- a/RELEASE_BODY.md
+++ b/RELEASE_BODY.md
@@ -1,15 +1,15 @@
 ## Summary
-This handoff summarizes 2 commit(s) across workflow scripts, tests, README/release docs between `origin/main~2` and `HEAD`.
+This PR adds release handoff documents for the workflow-contracts validation refactor that is already merged on `main`.
 
-## Latest commits
-- 67379c0 Tighten workflow docs and feature validation
-- d71ef59 Refactor workflow contracts and validation hooks
+## Commit in this branch
+- 8636e87 Add release handoff docs for workflow refactor
 
-## Highlights
-- workflow scripts: `.workflow/scripts/artifact_renderers.py`, `.workflow/scripts/artifact_schema.py`, `.workflow/scripts/artifact_store.py` 외 15개
-- claude workflow assets: `.claude/settings.json`, `.claude/skills/README.md`, `.claude/skills/flow-feature.md` 외 5개
-- tests: `tests/test_execute.py`, `tests/test_hooks.py`, `tests/test_install.py`
-- repo docs: `README.md`
+## Added files
+- `RELEASE_NOTES.md`
+- `RELEASE_BODY.md`
+
+## Context covered by the handoff
+The handoff documents summarize the already-landed workflow refactor work on `main`, including workflow contract extraction, validation hook tightening, related workflow docs updates, and regression coverage.
 
 ## Verification
 ```bash

--- a/RELEASE_BODY.md
+++ b/RELEASE_BODY.md
@@ -1,0 +1,17 @@
+## Summary
+This handoff summarizes 2 commit(s) across workflow scripts, tests, README/release docs between `origin/main~2` and `HEAD`.
+
+## Latest commits
+- 67379c0 Tighten workflow docs and feature validation
+- d71ef59 Refactor workflow contracts and validation hooks
+
+## Highlights
+- workflow scripts: `.workflow/scripts/artifact_renderers.py`, `.workflow/scripts/artifact_schema.py`, `.workflow/scripts/artifact_store.py` 외 15개
+- claude workflow assets: `.claude/settings.json`, `.claude/skills/README.md`, `.claude/skills/flow-feature.md` 외 5개
+- tests: `tests/test_execute.py`, `tests/test_hooks.py`, `tests/test_install.py`
+- repo docs: `README.md`
+
+## Verification
+```bash
+python3 -m pytest -q
+```

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,8 +3,9 @@
 ## Summary
 This branch adds release handoff documents for the workflow-contracts validation refactor that is already merged on `main`.
 
-## Commits
+## Commits in this branch
 - 8636e87 Add release handoff docs for workflow refactor
+- 53da8c6 docs: align release handoff with current PR
 
 ## Added files
 - `RELEASE_NOTES.md`

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,52 @@
+# Release Notes
+
+## Summary
+This handoff summarizes 2 commit(s) across workflow scripts, tests, README/release docs between `origin/main~2` and `HEAD`.
+
+## Commits
+- 67379c0 Tighten workflow docs and feature validation
+- d71ef59 Refactor workflow contracts and validation hooks
+
+## Changed files
+### workflow scripts
+- `.workflow/scripts/artifact_renderers.py`
+- `.workflow/scripts/artifact_schema.py`
+- `.workflow/scripts/artifact_store.py`
+- `.workflow/scripts/ccs_runner.py`
+- `.workflow/scripts/execute.py`
+- `.workflow/scripts/hooks/edit-error-recovery.sh`
+- `.workflow/scripts/hooks/tool-failure-tracker.sh`
+- `.workflow/scripts/hooks/tool-output-truncator.sh`
+- `.workflow/scripts/hooks/validate-output.sh`
+- `.workflow/scripts/mode_handlers.py`
+- `.workflow/scripts/payloads.py`
+- `.workflow/scripts/prompt_builder.py`
+- `.workflow/scripts/runner_commands.py`
+- `.workflow/scripts/runner_execution.py`
+- `.workflow/scripts/runner_resolution.py`
+- `.workflow/scripts/task_artifacts.py`
+- `.workflow/scripts/workflow_contracts.py`
+- `.workflow/scripts/workflow_tasks.py`
+
+### claude workflow assets
+- `.claude/settings.json`
+- `.claude/skills/README.md`
+- `.claude/skills/flow-feature.md`
+- `.claude/skills/flow-init.md`
+- `.claude/skills/flow-plan.md`
+- `.claude/skills/flow-qa.md`
+- `.claude/skills/flow-review.md`
+- `CLAUDE.md`
+
+### tests
+- `tests/test_execute.py`
+- `tests/test_hooks.py`
+- `tests/test_install.py`
+
+### repo docs
+- `README.md`
+
+## Verification
+```bash
+python3 -m pytest -q
+```

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,50 +1,20 @@
 # Release Notes
 
 ## Summary
-This handoff summarizes 2 commit(s) across workflow scripts, tests, README/release docs between `origin/main~2` and `HEAD`.
+This branch adds release handoff documents for the workflow-contracts validation refactor that is already merged on `main`.
 
 ## Commits
-- 67379c0 Tighten workflow docs and feature validation
-- d71ef59 Refactor workflow contracts and validation hooks
+- 8636e87 Add release handoff docs for workflow refactor
 
-## Changed files
-### workflow scripts
-- `.workflow/scripts/artifact_renderers.py`
-- `.workflow/scripts/artifact_schema.py`
-- `.workflow/scripts/artifact_store.py`
-- `.workflow/scripts/ccs_runner.py`
-- `.workflow/scripts/execute.py`
-- `.workflow/scripts/hooks/edit-error-recovery.sh`
-- `.workflow/scripts/hooks/tool-failure-tracker.sh`
-- `.workflow/scripts/hooks/tool-output-truncator.sh`
-- `.workflow/scripts/hooks/validate-output.sh`
-- `.workflow/scripts/mode_handlers.py`
-- `.workflow/scripts/payloads.py`
-- `.workflow/scripts/prompt_builder.py`
-- `.workflow/scripts/runner_commands.py`
-- `.workflow/scripts/runner_execution.py`
-- `.workflow/scripts/runner_resolution.py`
-- `.workflow/scripts/task_artifacts.py`
-- `.workflow/scripts/workflow_contracts.py`
-- `.workflow/scripts/workflow_tasks.py`
+## Added files
+- `RELEASE_NOTES.md`
+- `RELEASE_BODY.md`
 
-### claude workflow assets
-- `.claude/settings.json`
-- `.claude/skills/README.md`
-- `.claude/skills/flow-feature.md`
-- `.claude/skills/flow-init.md`
-- `.claude/skills/flow-plan.md`
-- `.claude/skills/flow-qa.md`
-- `.claude/skills/flow-review.md`
-- `CLAUDE.md`
-
-### tests
-- `tests/test_execute.py`
-- `tests/test_hooks.py`
-- `tests/test_install.py`
-
-### repo docs
-- `README.md`
+## Covers
+These handoff docs summarize the already-landed workflow refactor work from `main`, including:
+- workflow contract extraction and validation-hook refactor
+- related README / CLAUDE / skill docs updates
+- execute / hooks / install regression coverage
 
 ## Verification
 ```bash


### PR DESCRIPTION
## Summary
This PR adds release handoff documents for the workflow-contracts validation refactor that is already merged on `main`.

## Commits in this branch
- 8636e87 Add release handoff docs for workflow refactor
- 53da8c6 docs: align release handoff with current PR

## Added files
- `RELEASE_NOTES.md`
- `RELEASE_BODY.md`

## Context covered by the handoff
The handoff documents summarize the already-landed workflow refactor work on `main`, including workflow contract extraction, validation hook tightening, related workflow docs updates, and regression coverage.

## Verification
```bash
python3 -m pytest -q
```